### PR TITLE
fix: adapt to git2 0.21 string accessor API changes

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -69,7 +69,7 @@ impl Commit {
   ///
   /// `None` will be returned if the message is not valid utf-8
   pub fn message(&self) -> Option<&str> {
-    self.inner.message()
+    self.inner.message().ok()
   }
 
   #[napi]
@@ -87,7 +87,7 @@ impl Commit {
   ///
   /// `None` will be returned if the encoding is not known
   pub fn message_encoding(&self) -> Option<&str> {
-    self.inner.message_encoding()
+    self.inner.message_encoding().ok().flatten()
   }
 
   #[napi]
@@ -95,7 +95,7 @@ impl Commit {
   ///
   /// `None` will be returned if the message is not valid utf-8
   pub fn message_raw(&self) -> Option<&str> {
-    self.inner.message_raw()
+    self.inner.message_raw().ok()
   }
 
   #[napi]
@@ -109,7 +109,7 @@ impl Commit {
   ///
   /// `None` will be returned if the message is not valid utf-8
   pub fn raw_header(&self) -> Option<&str> {
-    self.inner.raw_header()
+    self.inner.raw_header().ok()
   }
 
   #[napi]
@@ -137,7 +137,7 @@ impl Commit {
   /// `None` may be returned if an error occurs or if the summary is not valid
   /// utf-8.
   pub fn summary(&self) -> Option<&str> {
-    self.inner.summary()
+    self.inner.summary().ok().flatten()
   }
 
   #[napi]
@@ -161,7 +161,7 @@ impl Commit {
   /// `None` may be returned if an error occurs or if the summary is not valid
   /// utf-8.
   pub fn body(&self) -> Option<&str> {
-    self.inner.body()
+    self.inner.body().ok().flatten()
   }
 
   #[napi]

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -140,7 +140,12 @@ impl Reference {
   /// May return `None` if the reference is either not symbolic or not a
   /// valid utf-8 string.
   pub fn symbolic_target(&self) -> Option<String> {
-    self.inner.symbolic_target().ok().flatten().map(|s| s.to_owned())
+    self
+      .inner
+      .symbolic_target()
+      .ok()
+      .flatten()
+      .map(|s| s.to_owned())
   }
 
   #[napi]

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -85,7 +85,7 @@ impl Reference {
   ///
   /// Returns `None` if the name is not valid utf-8.
   pub fn name(&self) -> Option<String> {
-    self.inner.name().map(|s| s.to_string())
+    self.inner.name().ok().map(|s| s.to_string())
   }
 
   #[napi]
@@ -96,7 +96,7 @@ impl Reference {
   ///
   /// Returns `None` if the shorthand is not valid utf-8.
   pub fn shorthand(&self) -> Option<String> {
-    self.inner.shorthand().map(|s| s.to_string())
+    self.inner.shorthand().ok().map(|s| s.to_string())
   }
 
   #[napi]
@@ -140,7 +140,7 @@ impl Reference {
   /// May return `None` if the reference is either not symbolic or not a
   /// valid utf-8 string.
   pub fn symbolic_target(&self) -> Option<String> {
-    self.inner.symbolic_target().map(|s| s.to_owned())
+    self.inner.symbolic_target().ok().flatten().map(|s| s.to_owned())
   }
 
   #[napi]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -200,7 +200,7 @@ impl Remote {
   /// Returns `None` if this remote has not yet been named or if the name is
   /// not valid utf-8
   pub fn name(&self) -> Option<&str> {
-    self.inner.name()
+    self.inner.name().ok().flatten()
   }
 
   #[napi]
@@ -208,7 +208,7 @@ impl Remote {
   ///
   /// Returns `None` if the url is not valid utf-8
   pub fn url(&self) -> Option<&str> {
-    self.inner.url()
+    self.inner.url().ok()
   }
 
   #[napi]
@@ -216,7 +216,7 @@ impl Remote {
   ///
   /// Returns `None` if the pushurl is not valid utf-8
   pub fn pushurl(&self) -> Option<&str> {
-    self.inner.pushurl()
+    self.inner.pushurl().ok().flatten()
   }
 
   #[napi]
@@ -232,7 +232,7 @@ impl Remote {
       .default_branch()
       .convert("Get the default branch of Remote failed")
       .and_then(|b| {
-        b.as_str().map(|name| name.to_owned()).ok_or_else(|| {
+        b.as_str().ok().map(|name| name.to_owned()).ok_or_else(|| {
           Error::new(
             Status::GenericFailure,
             "Default branch name contains non-utf-8 characters".to_string(),

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -372,7 +372,7 @@ impl Repository {
   /// If there is no namespace, or the namespace is not a valid utf8 string,
   /// `None` is returned.
   pub fn namespace(&self) -> Option<String> {
-    self.inner.namespace().map(|n| n.to_owned())
+    self.inner.namespace().ok().flatten().map(|n| n.to_owned())
   }
 
   #[napi]
@@ -420,8 +420,7 @@ impl Repository {
       .map(|remotes| {
         remotes
           .into_iter()
-          .flatten()
-          .map(|name| name.to_owned())
+          .filter_map(|name| name.ok().flatten().map(|name| name.to_owned()))
           .collect()
       })
       .convert("Fetch remotes failed")
@@ -531,8 +530,7 @@ impl Repository {
         .remote_rename(&name, &new_name)
         .convert(format!("Failed to rename remote [{}]", &name))?
         .into_iter()
-        .flatten()
-        .map(|s| s.to_owned())
+        .filter_map(|s| s.ok().flatten().map(|s| s.to_owned()))
         .collect::<Vec<_>>(),
     )
   }
@@ -754,7 +752,7 @@ impl Repository {
       .map(|tags| {
         tags
           .into_iter()
-          .filter_map(|s| s.map(|s| s.to_owned()))
+          .filter_map(|s| s.ok().flatten().map(|s| s.to_owned()))
           .collect()
       })
   }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -69,7 +69,7 @@ impl Signature {
   ///
   /// Returns `None` if the name is not valid utf-8
   pub fn name(&self) -> Option<&str> {
-    self.inner.name()
+    self.inner.name().ok()
   }
 
   #[napi]
@@ -77,7 +77,7 @@ impl Signature {
   ///
   /// Returns `None` if the email is not valid utf-8
   pub fn email(&self) -> Option<&str> {
-    self.inner.email()
+    self.inner.email().ok()
   }
 
   #[napi]

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -29,7 +29,7 @@ impl Tag {
   ///
   /// Returns None if there is no message or if it is not valid utf8
   pub fn message(&self) -> Option<String> {
-    self.inner.message().map(|s| s.to_string())
+    self.inner.message().ok().flatten().map(|s| s.to_string())
   }
 
   #[napi]
@@ -45,7 +45,7 @@ impl Tag {
   ///
   /// Returns None if it is not valid utf8
   pub fn name(&self) -> Option<String> {
-    self.inner.name().map(|s| s.to_string())
+    self.inner.name().ok().map(|s| s.to_string())
   }
 
   #[napi]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -193,6 +193,7 @@ impl TreeEntry {
     self
       .inner
       .name()
+      .ok()
       .ok_or_else(|| Error::from_reason("Invalid utf-8"))
   }
 


### PR DESCRIPTION
## Problem

The build no longer compiles (22 errors) after `git2` was bumped to **0.21.0**. Per the git2 0.21 changelog:

> ❗ Many string accessors that previously returned `Option<&str>` now return `Result<&str, Error>` or `Result<Option<&str>, Error>`, so callers can distinguish a missing value from a non-UTF-8 one.

`StringArray` iterators also changed their item type from `Option<&str>` to `Result<Option<&str>, Error>`, and `Buf::as_str` / `TreeEntry::name` now return `Result<&str, Error>`.

## Fix

Map the new return types back to the **existing `Option`-based public API** so the generated TypeScript bindings stay identical:

| git2 0.21 returns | wrapper fix | sites |
|---|---|---|
| `Result<&str, Error>` | `.ok()` | commit `message`/`message_raw`/`raw_header`, remote `url`, signature `name`/`email`, reference `name`/`shorthand`, tag `name` |
| `Result<Option<&str>, Error>` | `.ok().flatten()` | commit `message_encoding`/`summary`/`body`, remote `name`/`pushurl`, repo `namespace`, reference `symbolic_target`, tag `message` |
| `Buf::as_str` / `TreeEntry::name` → `Result<&str, Error>` | `.ok()` then existing `ok_or_else` | remote `default_branch`, tree entry `name` |
| `StringArray` iter item → `Result<Option<&str>, Error>` | `.filter_map(\|s\| s.ok().flatten()…)` | repo `remotes` / `remote_rename` / `tag_names` |

`.ok()` / `.ok().flatten()` exactly matches each method's documented "`None` if not valid utf-8" contract, and the two `ok_or_else` sites keep their custom error messages.

## Verification

- `cargo build --release` → finished, 0 errors
- `yarn build` → native binary built clean
- `yarn test` → **7 tests passed**
- Public API unchanged — `index.d.ts` / `index.js` not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)